### PR TITLE
Tcp proxy connection method

### DIFF
--- a/sockets/rawtcp.go
+++ b/sockets/rawtcp.go
@@ -3,6 +3,7 @@ package sockets
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/preludeorg/pneuma/util"
@@ -57,7 +58,11 @@ func dialProxiedTCPConnection(proxyUrl *url.URL, agent *util.AgentConfig) (net.C
 		return conn, err
 	}
 
-	if _, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\n\r\n", agent.Address); err != nil {
+	connectHeader := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n", agent.Address, agent.Address)
+	if proxyUrl.User.String() != "" {
+		connectHeader += fmt.Sprintf("Proxy-Authorization: basic %s\r\n", base64.StdEncoding.EncodeToString([]byte(proxyUrl.User.String())))
+	}
+	if _, err = fmt.Fprint(conn, connectHeader); err != nil {
 		util.DebugLogf("Error writing to proxy socket")
 	}
 	return conn, err

--- a/sockets/rawtcp.go
+++ b/sockets/rawtcp.go
@@ -10,9 +10,12 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 )
 
 type TCP struct {}
+
+var proxyOnce sync.Once
 
 func init() {
 	util.CommunicationChannels["tcp"] = TCP{}

--- a/sockets/rawtcp.go
+++ b/sockets/rawtcp.go
@@ -20,7 +20,7 @@ func init() {
 
 func (contact TCP) Communicate(agent *util.AgentConfig, beacon util.Beacon) (util.Beacon, error) {
 	for agent.Contact == "tcp" {
-		conn, err := net.Dial("tcp", agent.Address)
+		conn, err := dialTCPConnection(agent)
 	   	if err != nil {
 	   		util.DebugLogf("[-] %s is either unavailable or a firewall is blocking traffic.", agent.Address)
 	   	} else {

--- a/sockets/rawtcp.go
+++ b/sockets/rawtcp.go
@@ -10,12 +10,9 @@ import (
 	"net"
 	"net/url"
 	"strings"
-	"sync"
 )
 
 type TCP struct {}
-
-var proxyOnce sync.Once
 
 func init() {
 	util.CommunicationChannels["tcp"] = TCP{}


### PR DESCRIPTION
- Connect to the parsed TCP url, write an HTTP `CONNECT` message to the remote server, return the (hopefully) proxied TCP connection 