### PR TITLE
adding jitter between TTP executions

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/preludeorg/pneuma/sockets"
 	"github.com/preludeorg/pneuma/util"
 	"os"
@@ -21,6 +22,7 @@ func main() {
 	address := flag.String("address", agent.Address, "The ip:port of the socket listening post")
 	group := flag.String("range", agent.Range, "Which range to associate to")
 	sleep := flag.Int("sleep", agent.Sleep, "Number of seconds to sleep between beacons")
+	jitter := flag.Int("jitter", agent.Jitter, "Number of seconds to sleep between TTPs")
 	useragent := flag.String("useragent", agent.Useragent, "User agent used when connecting (HTTP/S only)")
 	proxy := flag.String("proxy", agent.Proxy, "Set a proxy URL target (HTTP/S only)")
 	util.DebugMode = flag.Bool("debug", false, "Write debug output to console")
@@ -32,8 +34,10 @@ func main() {
 		"Range": *group,
 		"Useragent": *useragent,
 		"Sleep": *sleep,
+		"Jitter": *jitter,
 		"Proxy": *proxy,
 	})
+	fmt.Println(*jitter)
 	if *util.DebugMode {
 		util.ShowConsole()
 	}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"github.com/preludeorg/pneuma/sockets"
 	"github.com/preludeorg/pneuma/util"
 	"os"
@@ -37,7 +36,6 @@ func main() {
 		"Jitter": *jitter,
 		"Proxy": *proxy,
 	})
-	fmt.Println(*jitter)
 	if *util.DebugMode {
 		util.ShowConsole()
 	}

--- a/sockets/contact.go
+++ b/sockets/contact.go
@@ -38,6 +38,7 @@ func runLinks(tempB *util.Beacon, beacon *util.Beacon, agent *util.AgentConfig, 
 		}
 		beacon.Links = append(beacon.Links, link)
 		agent.EndInstruction(link)
+		jitterSleep(agent.Jitter, "JITTER")
 	}
 }
 

--- a/util/config.go
+++ b/util/config.go
@@ -47,6 +47,7 @@ type AgentConfig struct {
 	Address   string
 	Useragent string
 	Sleep     int
+	Jitter 	  int
 	KillSleep int
 	CommandTimeout int
 	Pid int
@@ -102,6 +103,7 @@ func (c *AgentConfig) SetAgentConfig(ac map[string]interface{}) {
 	c.Useragent = applyKey(c.Useragent, ac, "Useragent").(string)
 	c.Proxy = applyKey(c.Proxy, ac, "Proxy").(string)
 	c.Sleep = applyKey(c.Sleep, ac, "Sleep").(int)
+	c.Jitter = applyKey(c.Jitter, ac, "Jitter").(int)
 	if key, ok := ac["Contact"]; ok {
 		if _, ok = CommunicationChannels[strings.ToLower(key.(string))]; ok {
 			c.Contact = strings.ToLower(key.(string))


### PR DESCRIPTION
Sleep already exists between beacons via the -sleep parameter (in seconds). This adds -jitter to add a pause between running TTPs. 

This was my natural way of adding this property - however, I also thought about indirectly adding the jitter via a simple algorithm against the existing sleep property. For example, could we determine jitter based on 33% of the sleep value?

https://github.com/preludeorg/operator-support/issues/150