### PR TITLE
Adding a goembed config to simply agent configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This agent can be used with Operator, as designed, or pointed at any command-and
 
 ## Getting started
 
-Clone this repository. Then ensure GoLang 1.13+ is installed before continuing.
+Clone this repository. Then ensure GoLang 1.16+ is installed before continuing.
 
 To use the agent, install GoLang then start the agent against whichever protocol you want:
 
@@ -46,7 +46,7 @@ On windows you can build with:
 This will output a file (into the payloads directory) for each supported operating system, which you can copy to any target system and execute normally
 to start the agent. 
 
-> Before you compile, consider changing the AESKey variable inside config.go. This value represents
+> Before you compile, consider changing the AESKey variable inside conf/default.json. This value represents
 > the encryption key to encrypt/decrypt communications with Prelude Operator. This key must be 32-characters
 > and must match the encryption key in the Prelude Operator Emulate section. Also consider
 > changing the default address parameters in main.go, so you can start your agent without command-line arguments.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On windows you can build with:
 This will output a file (into the payloads directory) for each supported operating system, which you can copy to any target system and execute normally
 to start the agent. 
 
-> Before you compile, consider changing the AESKey variable inside conf/default.json. This value represents
+> Before you compile, consider changing the AESKey variable inside util/conf/default.json. This value represents
 > the encryption key to encrypt/decrypt communications with Prelude Operator. This key must be 32-characters
 > and must match the encryption key in the Prelude Operator Emulate section. Also consider
 > changing the default address parameters in main.go, so you can start your agent without command-line arguments.

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	sleep := flag.Int("sleep", agent.Sleep, "Number of seconds to sleep between beacons")
 	useragent := flag.String("useragent", agent.Useragent, "User agent used when connecting (HTTP/S only)")
 	proxy := flag.String("proxy", agent.Proxy, "Set a proxy URL target (HTTP/S only)")
-	util.DebugMode = flag.Bool("debug", false, "Write debug output to console")
+	util.DebugMode = flag.Bool("debug", agent.Debug, "Write debug output to console")
 	flag.Parse()
 	agent.SetAgentConfig(map[string]interface{}{
 		"Name": *name,

--- a/util/conf/default.json
+++ b/util/conf/default.json
@@ -1,0 +1,12 @@
+{
+  "AESKey": "abcdefghijklmnopqrstuvwxyz012345",
+  "Range": "red",
+  "Contact": "tcp",
+  "Address": "127.0.0.1:2323",
+  "Useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36",
+  "Sleep": 60,
+  "KillSleep": 5,
+  "CommandTimeout": 60,
+  "Proxy": "",
+  "Debug": false
+}

--- a/util/config.go
+++ b/util/config.go
@@ -90,6 +90,7 @@ func BuildAgentConfig() *AgentConfig {
 	agent.Name = pickName(12)
 	agent.Pid = os.Getpid()
 	agent.Executing = make(map[string]Instruction)
+	DebugMode = &agent.Debug
 	return &agent
 }
 

--- a/util/config.go
+++ b/util/config.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"crypto/md5"
+	"embed"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -16,6 +17,9 @@ import (
 	"strings"
 	"time"
 )
+
+//go:embed conf/default.json
+var defaultConfig embed.FS
 
 var DebugMode *bool
 
@@ -41,7 +45,7 @@ type Operation interface {
 
 type AgentConfig struct {
 	Name 	  string
-	AESKey    []byte
+	AESKey    string
 	Range     string
 	Contact   string
 	Address   string
@@ -51,6 +55,7 @@ type AgentConfig struct {
 	CommandTimeout int
 	Pid int
 	Proxy string
+	Debug bool
 	Executing map[string]Instruction
 }
 
@@ -79,25 +84,18 @@ type Instruction struct {
 }
 
 func BuildAgentConfig() *AgentConfig {
-	return &AgentConfig{
-		Name:      pickName(12),
-		AESKey:    []byte("abcdefghijklmnopqrstuvwxyz012345"),
-		Range:     "red",
-		Contact:   "tcp",
-		Address:   "127.0.0.1:2323",
-		Useragent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36",
-		Sleep:     60,
-		KillSleep: 5,
-		CommandTimeout: 60,
-		Pid: os.Getpid(),
-		Proxy: "",
-		Executing: make(map[string]Instruction),
-	}
+	var agent AgentConfig
+	data, _ := defaultConfig.ReadFile("conf/default.json")
+	json.Unmarshal(data, &agent)
+	agent.Name = pickName(12)
+	agent.Pid = os.Getpid()
+	agent.Executing = make(map[string]Instruction)
+	return &agent
 }
 
 func (c *AgentConfig) SetAgentConfig(ac map[string]interface{}) {
 	c.Name = applyKey(c.Name, ac, "Name").(string)
-	c.AESKey = applyKey(c.AESKey, ac, "AESKey").([]byte)
+	c.AESKey = applyKey(c.AESKey, ac, "AESKey").(string)
 	c.Range = applyKey(c.Range, ac, "Range").(string)
 	c.Useragent = applyKey(c.Useragent, ac, "Useragent").(string)
 	c.Proxy = applyKey(c.Proxy, ac, "Proxy").(string)

--- a/util/config.go
+++ b/util/config.go
@@ -203,9 +203,6 @@ func applyKey(curr interface{}, ac map[string]interface{}, key string) interface
 		if key == "Sleep" && reflect.TypeOf(val).Kind() == reflect.Float64 {
 			return int(reflect.ValueOf(val).Float())
 		}
-		if key == "AESKey" && reflect.TypeOf(val).Kind() == reflect.String{
-			return []byte(val.(string))
-		}
 		return val
 	}
 	return curr

--- a/util/config.go
+++ b/util/config.go
@@ -90,7 +90,6 @@ func BuildAgentConfig() *AgentConfig {
 	agent.Name = pickName(12)
 	agent.Pid = os.Getpid()
 	agent.Executing = make(map[string]Instruction)
-	DebugMode = &agent.Debug
 	return &agent
 }
 

--- a/util/cryptic.go
+++ b/util/cryptic.go
@@ -11,7 +11,7 @@ import (
 	"io"
 )
 
-var EncryptionKey *[]byte
+var EncryptionKey *string
 
 //Encrypt the results
 func Encrypt(bites []byte) []byte {
@@ -20,7 +20,7 @@ func Encrypt(bites []byte) []byte {
 		DebugLog(err)
 		return make([]byte, 0)
 	}
-	block, _ := aes.NewCipher(*EncryptionKey)
+	block, _ := aes.NewCipher([]byte(*EncryptionKey))
 	cipherText := make([]byte, aes.BlockSize+len(plainText))
 	iv := cipherText[:aes.BlockSize]
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
@@ -34,7 +34,7 @@ func Encrypt(bites []byte) []byte {
 //Decrypt a command
 func Decrypt(text string) string {
 	cipherText, _ := hex.DecodeString(text)
-	block, err := aes.NewCipher(*EncryptionKey)
+	block, err := aes.NewCipher([]byte(*EncryptionKey))
 	if err != nil {
 		DebugLog(err)
 		return ""


### PR DESCRIPTION
Moves agent configuration to a standalone json file in the `util/conf/default.json`. 
Simplifies the creation of the agent configuration by directly loading the JSON 