### PR TITLE
moving payload location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 .idea/*
 *.history/*
 .idea
-compiled/*
-payloads/*

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 param([String]$randomHash="JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA")
 $env:GOOS='windows';
-go build -ldflags="-s -w -X main.randomHash=$randomHash" -o payloads/pneuma-windows.exe main.go;
+go build -ldflags="-s -w -X main.randomHash=$randomHash" -o pneuma-windows.exe main.go;
 $env:GOOS='darwin';
-go build -ldflags="-s -w -X main.randomHash=$randomHash" -o payloads/pneuma-darwin main.go;
+go build -ldflags="-s -w -X main.randomHash=$randomHash" -o pneuma-darwin main.go;
 $env:GOOS='linux';
-go build -ldflags="-s -w -X main.randomHash=$randomHash" -o payloads/pneuma-linux main.go;
+go build -ldflags="-s -w -X main.randomHash=$randomHash" -o pneuma-linux main.go;

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-GOOS=darwin go build -ldflags="-s -w -X main.randomHash=${1}" -o payloads/pneuma-darwin main.go;
-GOOS=linux go build -ldflags="-s -w -X main.randomHash=${1}" -o payloads/pneuma-linux main.go;
-GOOS=windows go build -ldflags="-s -w -X main.randomHash=${1}" -o payloads/pneuma-windows.exe main.go;
+GOOS=darwin go build -ldflags="-s -w -X main.randomHash=${1}" -o pneuma-darwin main.go;
+GOOS=linux go build -ldflags="-s -w -X main.randomHash=${1}" -o pneuma-linux main.go;
+GOOS=windows go build -ldflags="-s -w -X main.randomHash=${1}" -o pneuma-windows.exe main.go;


### PR DESCRIPTION
Moving the payload output to root, which matches the location we use in our TTP payload properties. Example:
```
#{operator.payloads}/pneuma/pneuma-windows.exe
```