### PR TITLE
Add a HTTP Header file hash  when sending a payload request

### DIFF
--- a/sockets/contact.go
+++ b/sockets/contact.go
@@ -57,9 +57,8 @@ func refreshBeacon(agent *util.AgentConfig, beacon *util.Beacon) {
 }
 
 func requestPayload(target string) (string, error) {
-	workingDir := "./"
 	filename := path.Base(target)
-	payloadPath := filepath.Join(workingDir, filename)
+	payloadPath := filepath.Join("./", filename)
 	body, code, err := requestHTTPPayload(target, payloadHash(payloadPath))
 	if err != nil {
 		return "", err

--- a/sockets/contact.go
+++ b/sockets/contact.go
@@ -2,8 +2,6 @@ package sockets
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"github.com/preludeorg/pneuma/commands"
@@ -84,13 +82,9 @@ func requestPayload(target string) (string, error) {
 
 func payloadHash(filepath string) string {
 	if _, err := os.Stat(filepath); !os.IsNotExist(err) {
-		data, err := os.ReadFile(filepath)
-		if err != nil {
-			return ""
+		if data, err := os.ReadFile(filepath); err == nil {
+			return util.Sha256(data)
 		}
-		h := sha256.New()
-		h.Write(data)
-		return hex.EncodeToString(h.Sum(nil))
 	}
 	return ""
 }

--- a/sockets/contact.go
+++ b/sockets/contact.go
@@ -57,15 +57,16 @@ func refreshBeacon(agent *util.AgentConfig, beacon *util.Beacon) {
 }
 
 func requestPayload(target string) (string, error) {
+	wd, _ := os.Getwd()
 	filename := path.Base(target)
-	payloadPath := filepath.Join("./", filename)
+	payloadPath := filepath.Join(wd, filename)
 	body, code, err := requestHTTPPayload(target, payloadHash(payloadPath))
 	if err != nil {
 		return "", err
 	}
 	switch code {
 	case 204:
-		return target, nil
+		return payloadPath, nil
 	case 200:
 		if err = util.SaveFile(bytes.NewReader(body), payloadPath); err != nil {
 			return "", err

--- a/sockets/contact.go
+++ b/sockets/contact.go
@@ -75,6 +75,8 @@ func requestPayload(target string) (string, error) {
 			return "", err
 		}
 		return payloadPath, nil
+	case 404:
+		return "", errors.New(fmt.Sprintf("[HTTP %d] Payload not found: %s", code, target))
 	default:
 		return "", errors.New(fmt.Sprintf("UNHANDLED PAYLOAD EXCEPTION: HTTP [%d]", code))
 	}

--- a/sockets/rawhttp.go
+++ b/sockets/rawhttp.go
@@ -68,12 +68,11 @@ func setHTTPProxyConfiguration(agent *util.AgentConfig) {
 }
 
 func requestHTTPPayload(address string, filehash string) ([]byte, int, error) {
-	valid, err := checkValidHTTPTarget(address)
-	if valid {
-		body, _, code, netErr := requestWithHeaders(address, "GET", []byte{}, 1800, map[string]string{"existing": filehash})
-		return body, code, netErr
+	if valid, err := checkValidHTTPTarget(address); !valid {
+		return nil, 0, err
 	}
-	return nil, 0, err
+	body, _, code, netErr := requestWithHeaders(address, "GET", []byte{}, 1800, map[string]string{"existing": filehash})
+	return body, code, netErr
 }
 
 func beaconPOST(address string, beacon util.Beacon) []byte {

--- a/util/cryptic.go
+++ b/util/cryptic.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -45,6 +46,13 @@ func Decrypt(text string) string {
 	mode.CryptBlocks(cipherText, cipherText)
 	cipherText, _ = unpad(cipherText, aes.BlockSize)
 	return fmt.Sprintf("%s", cipherText)
+}
+
+//Sha256 return a sha256 string
+func Sha256(data []byte) string {
+	h := sha256.New()
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func pad(buf []byte, size int) ([]byte, error) {


### PR DESCRIPTION
* cleans up some poorly designed functions
* check if a payload exists + generate a shasum
* adds function to send HTTP requests with headers 