### PR TITLE
change default python executor to python.exe

### DIFF
--- a/commands/commands_windows.go
+++ b/commands/commands_windows.go
@@ -17,7 +17,7 @@ func getShellCommand(ctx context.Context, executor, command string) *exec.Cmd {
 	var cmd *exec.Cmd
 	switch executor {
 	case "python":
-		cmd = exec.CommandContext(ctx, "python3.exe", "-c", command)
+		cmd = exec.CommandContext(ctx, "python.exe", "-c", command)
 	case "cmd":
 		cmd = exec.CommandContext(ctx, "cmd.exe")
 		cmd.SysProcAttr = getSysProcAttrs()


### PR DESCRIPTION
pneuma currently uses `python3.exe -c ..` to execute python commands.  by default, python installs without a python3.exe alias causing these commands will fail.