### PR TITLE
Fix for an edge case

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
@@ -160,6 +161,7 @@ func (c *AgentConfig) BuildExecutingHash() string {
 func (c *AgentConfig) BuildBeacon() Beacon {
 	pwd, _ := os.Getwd()
 	executable, _ := os.Executable()
+	_ = os.Chdir(filepath.Dir(executable))
 	hostname, _ := os.Hostname()
 	return Beacon{
 		Name:      c.Name,


### PR DESCRIPTION
This mostly applies to OSX from what I have seen but the use `occupy_eip` was hitting a case where pneuma's location was not the working directory location at agent start. This ensures that the working location is set to the file location at agent start. 

This might cause issues when someone launches pneuma from another directory and runs a ttp, and that ttp downloads a payload as that payload will be downloaded to the pneuma directory and not where it was launched from.
